### PR TITLE
Fix: "t0Proportions" should be "t0Proportion"

### DIFF
--- a/API.md
+++ b/API.md
@@ -267,8 +267,8 @@ Request params:
     },
     t0Count: integer,
     t1Count: integer,
-    t0Proportions: float,
-    t1Proportions: float,
+    t0Proportion: float,
+    t1Proportion: float,
     absoluteDifferenceProportion: float,
     relativeDifferenceProportion: float
   }


### PR DESCRIPTION
@chaoran-chen I don't have commit access to this repo, so here's a PR.